### PR TITLE
Converted to use Python dataclasses. Moved methods to parents classes…

### DIFF
--- a/pykanka/child_types.py
+++ b/pykanka/child_types.py
@@ -1,65 +1,61 @@
 import typing
 import json
-from typing import List, Dict
+from typing import List, Optional
 
 import requests
 
 import pykanka
 import pykanka.child_subentries as st
 from pykanka.exceptions import *
+from dataclasses import dataclass
 
 
+@dataclass
 class GenericChildType:
-    """Generic class for child types. Shouldn't be used directly, it is used as a base class for specialized child types."""
+    client: Optional["pykanka.KankaClient"]
+    _parent: Optional["pykanka.entities.Entity"]
+    base_url: Optional[str] = str()  # Overridden by inheritors
+
+    """Generic class for child types. 
+    Shouldn't be used directly, it is used as a base class for specialized child types."""
     _possible_keys = list()  # Overridden by inheritors
     _key_replacer = list()  # Overridden by inheritors
     _file_keys = list()  # Overridden by inheritors
 
+    @dataclass
     class GenericChildData:
-        """Container class for a GenericChildType. Gets overridden by specialized child type data containers."""
-        def __init__(self, val: dict = None):
-            self.id = None
-            self.type = None
-            self.entity_id = None
-            self.name = None
+        name: str = None
+        id:         Optional[int] = None
+        type:       Optional[str] = None
+        entity_id:  Optional[int] = None
 
-            self.entry = None
-            self.entry_parsed = None
+        entry:          Optional[str] = None
+        entry_parsed:   Optional[str] = None
 
-            self.image = None
-            self.image_full = None
-            self.image_thumb = None
+        image:          Optional[str] = None
+        image_full:     Optional[str] = None
+        image_thumb:    Optional[str] = None
 
-            self.tags = None
+        tags:           Optional[List[int]] = None
 
-            self.focus_x = None
-            self.focus_y = None
+        focus_x:        Optional[float] = None
+        focus_y:        Optional[float] = None
 
-            self.has_custom_image = None
-            self.is_template = None
-            self.is_private = None
+        has_custom_image:   Optional[str] = None
+        is_template:        Optional[bool] = None
+        is_private:         Optional[bool] = None
 
-            self.created_by = None
-            self.created_at = None
-            self.updated_by = None
-            self.updated_at = None
+        # Should be datetimes, but will require some type conversions, likely
+        created_by:     Optional[str] = None
+        created_at:         Optional[str] = None
+        updated_by:         Optional[str] = None
+        updated_at:         Optional[str] = None
 
-            if val:
-                for key in val.keys():
-                    if f"{key}" in self.__dict__:
-                        self.__dict__[f"{key}"] = val[key]
-                    else:
-                        raise WrongParametersPassedToEntity(f"{key} has been passed to child class, but is not a valid parameter")
+        header_full:        Optional[str] = None
+        has_custom_header:  Optional[bool] = None
 
-    def __init__(self, client: "pykanka.KankaClient", parent: "pykanka.entities.Entity" = None):
-
-        self.client = client
-
-        self._parent = parent
-
+    def __post_init__(self):
         self.data = self.GenericChildData()
-
-        self.base_url = str()           # Overridden by inheritors
 
     @property
     def parent(self):
@@ -73,28 +69,35 @@ class GenericChildType:
             self._parent = pykanka.entities.Entity(self.client, child=self)
             return self._parent
 
+    @parent.setter
+    def parent(self, v: "pykanka.entities.Entity"):
+        self._parent = v
+
     @classmethod
-    def from_id(cls, client: "pykanka.KankaClient", child_id: int, parent: "pykanka.entities.Entity" = None, refresh=False) -> "GenericChildType":
-        obj = cls(client, parent=parent)
+    def from_id(cls, client: "pykanka.KankaClient", child_id: int, parent: "pykanka.entities.Entity" = None,
+                refresh=False) -> "GenericChildType":
+        obj = cls(client=client, _parent=parent)
 
         response = client.request_get(f"{obj.base_url}{child_id}", refresh=refresh)
 
         if not response.ok:
-            raise ResponseNotOkError(f"Response from {obj.base_url}{child_id} not OK, code {response.status_code}: {response.reason}")
+            raise ResponseNotOkError(
+                f"Response from {obj.base_url}{child_id} not OK, code {response.status_code}: {response.reason}")
 
-        obj.data = obj.data.__class__(response.json()["data"])
+        obj.data = obj.data.__class__(**response.json()["data"])
 
         return obj
 
     @classmethod
-    def from_json(cls, client: "pykanka.KankaClient", content: typing.Union[str, dict], parent: "pykanka.entities.Entity" = None) -> "GenericChildType":
+    def from_json(cls, client: "pykanka.KankaClient", content: typing.Union[str, dict],
+                  parent: "pykanka.entities.Entity" = None) -> "GenericChildType":
 
         if type(content) == str:
             content = json.loads(content)
 
-        obj = cls(client, parent=parent)
+        obj = cls(client, _parent=parent)
 
-        obj.data = obj.data.__class__(val=content)
+        obj.data = obj.data.__class__(**content)
 
         return obj
 
@@ -112,7 +115,7 @@ class GenericChildType:
         :return: requests.response
         """
 
-        payload, files = self._prepare_post(json_data, **kwargs)
+        payload, files = self.client._prepare_post(json_data, **kwargs)
 
         return self.client.request_post(f"{self.base_url}", json=payload)
 
@@ -137,7 +140,8 @@ class GenericChildType:
     def delete(self):
         return self.client.request_delete(f"{self.base_url}{self.data.id}")
 
-    def _prepare_post(self, json_data: str, **kwargs):  # implement support for image files (keys: image and map) when the API allows it
+    def _prepare_post(self, json_data: str,
+                      **kwargs):  # implement support for image files (keys: image and map) when the API allows it
         if json_data:
             values = json.loads(json_data)
             values.update(kwargs)
@@ -184,39 +188,32 @@ class GenericChildType:
         return self.client.request_get(self.data.image_full, stream=True).raw
 
 
+@dataclass()
 class Location(GenericChildType):
     """A class representing a location child contained within an Entity."""
 
     # keys accepted by POST and also delivered by GET as per API documentation
-    _possible_keys = ["name", "type", "parent_location_id", "tags", "is_private", "image_full", "map", "is_map_private", "header_full",
+    _possible_keys = ["name", "type", "parent_location_id", "tags", "is_private", "image_full", "map", "is_map_private",
+                      "header_full",
                       "has_custom_header"]
     # keys called differently in GET compared to POST as per API documentation, format: (get_version, post_version)
     _key_replacer = [("image_full", "image_url"), ("map", "map_url")]
     # fields that accept stream object, not yet supported in API 1.0
     _file_keys = ["image", "map"]
 
+    child_id: Optional[int] = None
+
+    @dataclass
     class LocationData(GenericChildType.GenericChildData):
-        def __init__(self, val: dict = None):
-            self.parent_location_id = None
-            self.is_map_private = None
-            self.map = None
-            self.header_full = None
-            self.has_custom_header = None
+        parent_location_id: Optional[int] = None
+        is_map_private: Optional[bool] = None
+        map: Optional[str] = None
 
-            super().__init__(val=val)
-
-    def __init__(self, client: "pykanka.KankaClient", parent: "pykanka.entities.Entity" = None):
+    def __post_init__(self):
         """
         Creates an empty Location. Consider using Location.from_id() or Location.from_json() instead.
-
-        :param client: KankaClient
-        :param parent: Entity
         """
-        super().__init__(client, parent=parent)
-
         self.data = self.LocationData()
-        self.child_id = None
-
         self.base_url = f"{self.client.campaign_base_url}locations/"
 
     def get_map_image(self) -> "requests.Response.raw":
@@ -224,9 +221,9 @@ class Location(GenericChildType):
         return self.client.request_get(self.data.map, stream=True).raw
 
 
+@dataclass
 class Character(GenericChildType):
     """A class representing a Character child contained within an Entity."""
-
     # keys accepted by POST and also delivered by GET as per API documentation
     _possible_keys = ["name", "entry", "title", "age", "sex", "pronouns", "type", "family_id", "location_id", "race_id",
                       "tags", "is_dead", "is_private", "image_full", "is_personality_visible", "header_full",
@@ -236,72 +233,56 @@ class Character(GenericChildType):
     # fields that accept stream object, not yet supported in API 1.0
     _file_keys = ["image"]
 
+    @dataclass
     class CharacterData(GenericChildType.GenericChildData):
-        def __init__(self, val: dict = None):
-            self.location_id = None
-            self.family_id = None
-            self.race_id = None
-            self.age = None
-            self.sex = None
-            self.pronouns = None
-            self.title = None
-            self.traits = None
-            self.is_dead = None
-            self.is_personality_visible = None
-            self.header_full = None
-            self.has_custom_header = None
+        location_id: Optional[int] = None
+        family_id: Optional[int] = None
+        race_id: Optional[int] = None
+        age: Optional[int] = None
+        sex: Optional[str] = None
+        pronouns: Optional[str] = None
+        title: Optional[str] = None
+        traits: Optional[List[int]] = None
+        is_dead: Optional[bool] = None
+        is_personality_visible: Optional[bool] = None
 
-            super().__init__(val=val)
-
-    def __init__(self, client: "pykanka.KankaClient", parent: "pykanka.entities.Entity" = None):
+    def __post_init__(self):
         """
         Creates an empty Character. Consider using Character.from_id() or Character.from_json() instead.
-
-        :param client: KankaClient
-        :param parent: Entity
         """
-        super().__init__(client, parent=parent)
 
         self.data = self.CharacterData()
-
         self.base_url = f"{self.client.campaign_base_url}characters/"
 
 
+@dataclass
 class Organisation(GenericChildType):
     """A class representing a Organisation child contained within an Entity."""
 
     # keys accepted by POST and also delivered by GET as per API documentation
-    _possible_keys = ["name", "entry", "type", "organization_id", "location_id", "tags", "is_private", "image_full", "header_full",
+    _possible_keys = ["name", "entry", "type", "organization_id", "location_id", "tags", "is_private", "image_full",
+                      "header_full",
                       "has_custom_header"]
     # keys called differently in GET compared to POST as per API documentation, format: (get_version, post_version)
     _key_replacer = [("image_full", "image_url")]
     # fields that accept stream object, not yet supported in API 1.0
     _file_keys = ["image"]
 
+    @dataclass
     class OrganisationData(GenericChildType.GenericChildData):
-        def __init__(self, val: dict = None):
-            self.organisation_id = None
-            self.location_id = None
-            self.members = None
-            self.header_full = None
-            self.has_custom_header = None
+        organisation_id: Optional[int] = None
+        location_id: Optional[int] = None
+        members: Optional[List[int]] = None
 
-            super().__init__(val=val)
-
-    def __init__(self, client: "pykanka.KankaClient", parent: "pykanka.entities.Entity" = None):
+    def __post_init__(self):
         """
         Creates an empty Organisation. Consider using Organisation.from_id() or Organisation.from_json() instead.
-
-        :param client: KankaClient
-        :param parent: Entity
         """
-        super().__init__(client, parent=parent)
-
         self.data = self.OrganisationData()
-
         self.base_url = f"{self.client.campaign_base_url}organisations/"
 
 
+@dataclass
 class Timeline(GenericChildType):
     """A class representing a Timeline child contained within an Entity."""
 
@@ -313,30 +294,21 @@ class Timeline(GenericChildType):
     # fields that accept stream object, not yet supported in API 1.0
     _file_keys = ["image"]
 
+    @dataclass
     class TimelineData(GenericChildType.GenericChildData):
-        def __init__(self, val: dict = None):
-            self.eras = None
-            self.timeline_id = None
-            self.revert_order = None
-            self.header_full = None
-            self.has_custom_header = None
+        eras: Optional[str] = None
+        timeline_id: Optional[int] = None
+        revert_order: Optional[bool] = None
 
-            super().__init__(val=val)
-
-    def __init__(self, client: "pykanka.KankaClient", parent: "pykanka.entities.Entity" = None):
+    def __post_init__(self):
         """
         Creates an empty Timeline. Consider using Timeline.from_id() or Timeline.from_json() instead.
-
-        :param client: KankaClient
-        :param parent: Entity
         """
-        super().__init__(client, parent=parent)
-
         self.data = self.TimelineData()
-
         self.base_url = f"{self.client.campaign_base_url}timelines/"
 
 
+@dataclass
 class Race(GenericChildType):
     """A class representing a Race child contained within an Entity."""
 
@@ -348,63 +320,46 @@ class Race(GenericChildType):
     # fields that accept stream object, not yet supported in API 1.0
     _file_keys = ["image"]
 
+    @dataclass
     class RaceData(GenericChildType.GenericChildData):
-        def __init__(self, val: dict = None):
-            self.race_id = None
-            self.header_full = None
-            self.has_custom_header = None
+        race_id: Optional[int] = None
 
-            super().__init__(val=val)
-
-    def __init__(self, client: "pykanka.KankaClient", parent: "pykanka.entities.Entity" = None):
+    def __post_init__(self):
         """
         Creates an empty Race. Consider using Race.from_id() or Race.from_json() instead.
-
-        :param client: KankaClient
-        :param parent: Entity
         """
-        super().__init__(client, parent=parent)
-
         self.data = self.RaceData()
-
         self.base_url = f"{self.client.campaign_base_url}races/"
 
 
+@dataclass
 class Family(GenericChildType):
     """A class representing a Family child contained within an Entity."""
 
     # keys accepted by POST and also delivered by GET as per API documentation
-    _possible_keys = ["name", "entry", "type", "location_id", "family_id", "tags", "is_private", "image_full", "header_full",
+    _possible_keys = ["name", "entry", "type", "location_id", "family_id", "tags", "is_private", "image_full",
+                      "header_full",
                       "has_custom_header"]
     # keys called differently in GET compared to POST as per API documentation, format: (get_version, post_version)
     _key_replacer = [("image_full", "image_url")]
     # fields that accept stream object, not yet supported in API 1.0
     _file_keys = ["image"]
 
+    @dataclass
     class FamilyData(GenericChildType.GenericChildData):
-        def __init__(self, val: dict = None):
-            self.members = None
-            self.location_id = None
-            self.family_id = None
-            self.header_full = None
-            self.has_custom_header = None
+        members: Optional[List[int]] = None
+        location_id: Optional[int] = None
+        family_id: Optional[int] = None
 
-            super().__init__(val=val)
-
-    def __init__(self, client: "pykanka.KankaClient", parent: "pykanka.entities.Entity" = None):
+    def __post_init__(self):
         """
         Creates an empty Family. Consider using Location.from_id() or Family.from_json() instead.
-
-        :param client: KankaClient
-        :param parent: Entity
         """
-        super().__init__(client, parent=parent)
-
         self.data = self.FamilyData()
-
         self.base_url = f"{self.client.campaign_base_url}families/"
 
 
+@dataclass
 class Note(GenericChildType):
     """A class representing a Note child contained within an Entity."""
 
@@ -416,71 +371,53 @@ class Note(GenericChildType):
     # fields that accept stream object, not yet supported in API 1.0
     _file_keys = ["image"]
 
+    @dataclass()
     class NoteData(GenericChildType.GenericChildData):
-        def __init__(self, val: dict = None):
-            self.is_pinned = None
-            self.note_id = None
-            self.header_full = None
-            self.has_custom_header = None
+        is_pinned: Optional[bool] = None
+        note_id: Optional[int] = None
 
-            super().__init__(val=val)
-
-    def __init__(self, client: "pykanka.KankaClient", parent: "pykanka.entities.Entity" = None):
+    def __post_init__(self):
         """
         Creates an empty Note. Consider using Note.from_id() or Note.from_json() instead.
-
-        :param client: KankaClient
-        :param parent: Entity
         """
-        super().__init__(client, parent=parent)
-
         self.data = self.NoteData()
-
         self.base_url = f"{self.client.campaign_base_url}notes/"
 
 
+@dataclass
 class Map(GenericChildType):
     """A class representing a Map child contained within an Entity."""
 
     # keys accepted by POST and also delivered by GET as per API documentation
-    _possible_keys = ["name", "entry", "type", "map_id", "location_id", "center_marker_id", "center_x", "center_y", "tags", "is_private", "image_full", "header_full",
+    _possible_keys = ["name", "entry", "type", "map_id", "location_id", "center_marker_id", "center_x", "center_y",
+                      "tags", "is_private", "image_full", "header_full",
                       "has_custom_header"]
     # keys called differently in GET compared to POST as per API documentation, format: (get_version, post_version)
     _key_replacer = [("image_full", "image_url")]
     # fields that accept stream object, not yet supported in API 1.0
     _file_keys = ["image"]
 
+    @dataclass
     class MapData(GenericChildType.GenericChildData):
-        def __init__(self, val: dict = None):
-            self.location_id = None
-            self.map_id = None
-            self.width = None
-            self.height = None
-            self.initial_zoom = None
-            self.center_x = None
-            self.center_y = None
-            self.max_zoom = None
-            self.min_zoom = None
-            self.layers = None
-            self.groups = None
-            self.grid = None
-            self.center_marker_id = None
-            self.header_full = None
-            self.has_custom_header = None
+        location_id: Optional[int] = None
+        map_id: Optional[int] = None
+        width: Optional[float] = None
+        height: Optional[float] = None
+        initial_zoom: Optional[float] = None
+        center_x: Optional[float] = None
+        center_y: Optional[float] = None
+        max_zoom: Optional[float] = None
+        min_zoom: Optional[float] = None
+        layers: Optional[str] = None
+        groups: Optional[str] = None
+        grid: Optional[str] = None
+        center_marker_id: Optional[id] = None
 
-            super().__init__(val=val)
-
-    def __init__(self, client: "pykanka.KankaClient", parent: "pykanka.entities.Entity" = None):
+    def __post_init__(self):
         """
         Creates an empty Map. Consider using Map.from_id() or Map.from_json() instead.
-
-        :param client: KankaClient
-        :param parent: Entity
         """
-        super().__init__(client, parent=parent)
-
         self.data = self.MapData()
-
         self.base_url = f"{self.client.campaign_base_url}maps/"
 
     def all_markers(self) -> List["st.MapMarker"]:
@@ -524,234 +461,188 @@ class Map(GenericChildType):
             raise ValueError("either 'image' or 'image_url' is required, but both are missing")
 
 
+@dataclass
 class Tag(GenericChildType):
     """A class representing a Tag child contained within an Entity."""
 
     # keys accepted by POST and also delivered by GET as per API documentation
-    _possible_keys = ["name", "entry", "type", "colour", "tag_id", "is_private", "image_full" , "header_full",
+    _possible_keys = ["name", "entry", "type", "colour", "tag_id", "is_private", "image_full", "header_full",
                       "has_custom_header"]
     # keys called differently in GET compared to POST as per API documentation, format: (get_version, post_version)
     _key_replacer = [("image_full", "image_url")]
     # fields that accept stream object, not yet supported in API 1.0
     _file_keys = ["image"]
 
+    @dataclass
     class TagData(GenericChildType.GenericChildData):
-        def __init__(self, val: dict = None):
-            self.entities = None
-            self.tag_id = None
-            self.colour = None
-            self.header_full = None
-            self.has_custom_header = None
+        entities: Optional[List[int]] = None
+        tag_id: Optional[int] = None
+        colour: Optional[str] = None
 
-            super().__init__(val=val)
-
-    def __init__(self, client: "pykanka.KankaClient", parent: "pykanka.entities.Entity" = None):
+    def __post_init__(self):
         """
         Creates an empty Tag. Consider using Tag.from_id() or Tag.from_json() instead.
-
-        :param client: KankaClient
-        :param parent: Entity
         """
-        super().__init__(client, parent=parent)
-
         self.data = self.TagData()
-
         self.base_url = f"{self.client.campaign_base_url}tags/"
 
 
+@dataclass
 class Quest(GenericChildType):
     """A class representing a Quest child contained within an Entity."""
 
     # keys accepted by POST and also delivered by GET as per API documentation
-    _possible_keys = ["name", "entry", "type", "quest_id", "character_id", "tags", "is_private", "image_full" , "header_full",
+    _possible_keys = ["name", "entry", "type", "quest_id", "character_id", "tags", "is_private", "image_full",
+                      "header_full",
                       "has_custom_header"]
     # keys called differently in GET compared to POST as per API documentation, format: (get_version, post_version)
     _key_replacer = [("image_full", "image_url")]
     # fields that accept stream object, not yet supported in API 1.0
     _file_keys = ["image"]
 
+    @dataclass
     class QuestData(GenericChildType.GenericChildData):
-        def __init__(self, val: dict = None):
-            self.quest_id = None
-            self.character_id = None
-            self.calendar_id = None
-            self.calendar_year = None
-            self.calendar_month = None
-            self.calendar_day = None
-            self.date = None
-            self.elements_count = None
-            self.elements = None
-            self.is_completed = None
-            self.header_full = None
-            self.has_custom_header = None
+        quest_id: Optional[str] = None
+        character_id: Optional[str] = None
+        calendar_id: Optional[str] = None
+        calendar_year: Optional[str] = None
+        calendar_month: Optional[str] = None
+        calendar_day: Optional[str] = None
+        date: Optional[str] = None
+        elements_count: Optional[str] = None
+        elements: Optional[str] = None
+        is_completed: Optional[str] = None
 
-            super().__init__(val=val)
-
-    def __init__(self, client: "pykanka.KankaClient", parent: "pykanka.entities.Entity" = None):
+    def __post_init__(self):
         """
         Creates an empty Quest. Consider using Quest.from_id() or Quest.from_json() instead.
-
-        :param client: KankaClient
-        :param parent: Entity
         """
-        super().__init__(client, parent=parent)
-
         self.data = self.QuestData()
-
         self.base_url = f"{self.client.campaign_base_url}quests/"
 
 
+@dataclass
 class Journal(GenericChildType):
     """A class representing a Journal child contained within an Entity."""
 
     # keys accepted by POST and also delivered by GET as per API documentation
-    _possible_keys = ["name", "entry", "type", "date", "character_id", "tags", "is_private", "image_full", "header_full"]
+    _possible_keys = ["name", "entry", "type", "date", "character_id", "tags", "is_private", "image_full",
+                      "header_full"]
     # keys called differently in GET compared to POST as per API documentation, format: (get_version, post_version)
     _key_replacer = [("image_full", "image_url")]
     # fields that accept stream object, not yet supported in API 1.0
     _file_keys = ["image"]
 
+    @dataclass
     class JournalData(GenericChildType.GenericChildData):
-        def __init__(self, val: dict = None):
-            self.journal_id = None
-            self.location_id = None
-            self.character_id = None
-            self.calendar_id = None
-            self.calendar_year = None
-            self.calendar_month = None
-            self.calendar_day = None
-            self.date = None
-            self.header_full = None
-            self.has_custom_header = None
+        journal_id: Optional[int] = None
+        location_id: Optional[int] = None
+        character_id: Optional[int] = None
+        calendar_id: Optional[int] = None
+        calendar_year: Optional[str] = None
+        calendar_month: Optional[str] = None
+        calendar_day: Optional[str] = None
+        date: Optional[str] = None
 
-            super().__init__(val=val)
-
-    def __init__(self, client: "pykanka.KankaClient", parent: "pykanka.entities.Entity" = None):
+    def __post_init__(self):
         """
         Creates an empty Journal. Consider using Journal.from_id() or Journal.from_json() instead.
-
-        :param client: KankaClient
-        :param parent: Entity
         """
-        super().__init__(client, parent=parent)
-
         self.data = self.JournalData()
-
         self.base_url = f"{self.client.campaign_base_url}journals/"
 
 
+@dataclass
 class Item(GenericChildType):
     """A class representing a Item child contained within an Entity."""
 
     # keys accepted by POST and also delivered by GET as per API documentation
-    _possible_keys = ["name", "entry", "type", "location_id", "character_id", "price", "size", "tags", "is_private", "image_full", "header_full",
+    _possible_keys = ["name", "entry", "type", "location_id", "character_id", "price", "size", "tags", "is_private",
+                      "image_full", "header_full",
                       "has_custom_header"]
     # keys called differently in GET compared to POST as per API documentation, format: (get_version, post_version)
     _key_replacer = [("image_full", "image_url")]
     # fields that accept stream object, not yet supported in API 1.0
     _file_keys = ["image"]
 
+    @dataclass
     class ItemData(GenericChildType.GenericChildData):
-        def __init__(self, val: dict = None):
-            self.location_id = None
-            self.character_id = None
-            self.size = None
-            self.price = None
-            self.header_full = None
-            self.has_custom_header = None
+        location_id: Optional[int] = None
+        character_id: Optional[int] = None
+        size: Optional[float] = None
+        price: Optional[float] = None
 
-            super().__init__(val=val)
-
-    def __init__(self, client: "pykanka.KankaClient", parent: "pykanka.entities.Entity" = None):
+    def __post_init__(self):
         """
         Creates an empty Item. Consider using Item.from_id() or Item.from_json() instead.
-
-        :param client: KankaClient
-        :param parent: Entity
         """
-        super().__init__(client, parent=parent)
-
         self.data = self.ItemData()
-
         self.base_url = f"{self.client.campaign_base_url}items/"
 
 
+@dataclass
 class Event(GenericChildType):
     """A class representing a Event child contained within an Entity."""
 
     # keys accepted by POST and also delivered by GET as per API documentation
-    _possible_keys = ["name", "entry", "type", "date", "location_id", "tags", "is_private", "image_full" , "header_full",
+    _possible_keys = ["name", "entry", "type", "date", "location_id", "tags", "is_private", "image_full", "header_full",
                       "has_custom_header"]
     # keys called differently in GET compared to POST as per API documentation, format: (get_version, post_version)
     _key_replacer = [("image_full", "image_url")]
     # fields that accept stream object, not yet supported in API 1.0
     _file_keys = ["image"]
 
+    @dataclass
     class EventData(GenericChildType.GenericChildData):
-        def __init__(self, val: dict = None):
-            self.event_id = None
-            self.location_id = None
-            self.date = None
-            self.header_full = None
-            self.has_custom_header = None
+        event_id: Optional[int] = None
+        location_id: Optional[int] = None
+        date: Optional[str] = None
 
-            super().__init__(val=val)
-
-    def __init__(self, client: "pykanka.KankaClient", parent: "pykanka.entities.Entity" = None):
+    def __post_init__(self):
         """
         Creates an empty Event. Consider using Event.from_id() or Event.from_json() instead.
-
-        :param client: KankaClient
-        :param parent: Entity
         """
-        super().__init__(client, parent=parent)
-
         self.data = self.EventData()
-
         self.base_url = f"{self.client.campaign_base_url}events/"
 
 
+@dataclass
 class Ability(GenericChildType):
     """A class representing a Ability child contained within an Entity."""
 
     # keys accepted by POST and also delivered by GET as per API documentation
-    _possible_keys = ["name", "entry", "type", "ability_id", "charges", "tags", "is_private", "image_full" , "header_full",
+    _possible_keys = ["name", "entry", "type", "ability_id", "charges", "tags", "is_private", "image_full",
+                      "header_full",
                       "has_custom_header"]
     # keys called differently in GET compared to POST as per API documentation, format: (get_version, post_version)
     _key_replacer = [("image_full", "image_url")]
     # fields that accept stream object, not yet supported in API 1.0
     _file_keys = ["image"]
 
+    @dataclass
     class AbilityData(GenericChildType.GenericChildData):
-        def __init__(self, val: dict = None):
-            self.ability_id = None
-            self.abilities = None
-            self.charges = None
-            self.header_full = None
-            self.has_custom_header = None
+        ability_id: Optional[int] = None
+        abilities: Optional[str] = None
+        charges: Optional[str] = None
 
-            super().__init__(val=val)
-
-    def __init__(self, client: "pykanka.KankaClient", parent: "pykanka.entities.Entity" = None):
+    def __post_init__(self):
         """
         Creates an empty Ability. Consider using Ability.from_id() or Ability.from_json() instead.
 
-        :param client: KankaClient
-        :param parent: Entity
         """
-        super().__init__(client, parent=parent)
-
         self.data = self.AbilityData()
-
         self.base_url = f"{self.client.campaign_base_url}abilities/"
 
 
+@dataclass
 class Calendar(GenericChildType):
     """A class representing a Calendar child contained within an Entity"""
 
     # keys accepted by POST and also delivered by GET as per API documentation
-    _possible_keys = ["name", "entry", "type", "current_year", "current_month", "current_day", "tags", "month_name", "month_length", "month_type", "weekday", "year_name", "year_number",
-                      "moon_name", "moon_fullmoon", "epoch_name", "season_name", "season_month", "season_day", "has_leap_year", "leap_year_amount", "leap_year_offset", "leap_year_start",
+    _possible_keys = ["name", "entry", "type", "current_year", "current_month", "current_day", "tags", "month_name",
+                      "month_length", "month_type", "weekday", "year_name", "year_number",
+                      "moon_name", "moon_fullmoon", "epoch_name", "season_name", "season_month", "season_day",
+                      "has_leap_year", "leap_year_amount", "leap_year_offset", "leap_year_start",
                       "tags", "is_private", "image_full", "header_full",
                       "has_custom_header"]
     # keys called differently in GET compared to POST as per API documentation, format: (get_version, post_version)
@@ -759,38 +650,28 @@ class Calendar(GenericChildType):
     # fields that accept stream object, not yet supported in API 1.0
     _file_keys = ["image"]
 
+    @dataclass
     class CalendarData(GenericChildType.GenericChildData):
-        def __init__(self, val: dict = None):
-            self.suffix = None
-            self.parameters = None
-            self.weekdays = None
-            self.leap_year_offset = None
-            self.seasons = None
-            self.moons = None
-            self.leap_year_amount = None
-            self.leap_year_month = None
-            self.date = None
-            self.years = None
-            self.has_leap_year = None
-            self.leap_year_start = None
-            self.start_offset = None
-            self.months = None
-            self.header_full = None
-            self.has_custom_header = None
+        suffix: Optional[str] = None
+        parameters: Optional[str] = None
+        weekdays: Optional[str] = None
+        leap_year_offset: Optional[str] = None
+        seasons: Optional[str] = None
+        moons: Optional[str] = None
+        leap_year_amount: Optional[str] = None
+        leap_year_month: Optional[str] = None
+        date: Optional[str] = None
+        years: Optional[str] = None
+        has_leap_year: Optional[str] = None
+        leap_year_start: Optional[str] = None
+        start_offset: Optional[str] = None
+        months: Optional[str] = None
 
-            super().__init__(val=val)
-
-    def __init__(self, client: "pykanka.KankaClient", parent: "pykanka.entities.Entity" = None):
+    def __post_init__(self):
         """
         Creates an empty Calendar. Consider using Ability.from_id() or Ability.from_json() instead.
-
-        :param client: KankaClient
-        :param parent: Entity
         """
-        super().__init__(client, parent=parent)
-
         self.data = self.CalendarData()
-
         self.base_url = f"{self.client.campaign_base_url}calendars/"
 
     @staticmethod

--- a/pykanka/kanka_client.py
+++ b/pykanka/kanka_client.py
@@ -293,7 +293,7 @@ class KankaClient:
         return self._get_all_of_type(f"{self.campaign_base_url}abilities", ct.Ability)
 
     def all_calendars(self) -> Tuple[typing.Generator["ct.Calendar", None, None], int]:
-        return self._get_all_of_type(f"{self.campaign_base_url}calenders", ct.Calendar)
+        return self._get_all_of_type(f"{self.campaign_base_url}calendars", ct.Calendar)
 
     def search(self, name: str, results: int = 1) -> List["ent.Entity"]:
         """


### PR DESCRIPTION
… where at all possible. Fixed a few errors. There's one outstanding thing that rubs me the wrong way. I had to change the keyword to be "_parent" instead of "parent" saving to an internal variable of "_parent". I couldn't figure out a way around this without causing more issues

In looking into more of that "_parent" issue, I feel like the "ChildDataTypes" classes should not be inside the "ChildType" classes. I think there's quite a few simplifications that can be made if they're split. 